### PR TITLE
Small bug fixes

### DIFF
--- a/app/controllers/fplteams_controller.rb
+++ b/app/controllers/fplteams_controller.rb
@@ -13,7 +13,7 @@ class FplteamsController < ApplicationController
     all_data["events"].each do |num|
       if num["is_current"] == true
         @gameweek = num["id"]
-        @deadline = Time.zone.parse(num["deadline_time"]).utc
+        @deadline = Time.zone.parse(num["deadline_time"]).in_time_zone("London")
       end
     end
     @manager = Fplteam.find(params[:id])

--- a/app/jobs/get_current_picks_job.rb
+++ b/app/jobs/get_current_picks_job.rb
@@ -20,9 +20,9 @@ class GetCurrentPicksJob < ApplicationJob
     all_data["events"].each do |num|
       if num["is_next"] == true
         next_deadline = Time.zone.parse(num["deadline_time"]).utc
+        next_deadline_minus_one = next_deadline - 24.hours
       end
     end
-    next_deadline_minus_one = next_deadline - 24.hours
     # go through every fplteam
     unless Pick.last.gameweek == gameweek
       puts "getting picks for gameweek #{gameweek}"
@@ -45,7 +45,9 @@ class GetCurrentPicksJob < ApplicationJob
         end
       end
     end
-    UpdatePlayerStatsJob.set(wait_until: next_deadline_minus_one).perform_later
+    unless gameweek == 38
+      UpdatePlayerStatsJob.set(wait_until: next_deadline_minus_one).perform_later
+    end
     UpdatePenaltiesJob.perform_now
     UpdateTeamScoresJob.set(wait: 1.minute).perform_later
   end

--- a/app/jobs/get_current_picks_job.rb
+++ b/app/jobs/get_current_picks_job.rb
@@ -19,7 +19,7 @@ class GetCurrentPicksJob < ApplicationJob
     end
     all_data["events"].each do |num|
       if num["is_next"] == true
-        next_deadline = Time.zone.parse(num["deadline_time"]).utc
+        next_deadline = Time.zone.parse(num["deadline_time"]).in_time_zone("London")
         next_deadline_minus_one = next_deadline - 24.hours
       end
     end

--- a/app/jobs/update_player_stats_job.rb
+++ b/app/jobs/update_player_stats_job.rb
@@ -16,7 +16,7 @@ class UpdatePlayerStatsJob < ApplicationJob
     all_data["events"].each do |num|
       if num["is_next"] == true
         gameweek = num["id"]
-        deadline = Time.zone.parse(num["deadline_time"]).utc
+        deadline = Time.zone.parse(num["deadline_time"]).in_time_zone("London")
       end
     end
     # new version below, commenting while i work this out

--- a/app/services/gameweek.rb
+++ b/app/services/gameweek.rb
@@ -20,7 +20,7 @@ class Gameweek
   def get_deadline
     @all_gameweeks.each do |num|
       if num["is_#{@time_relative}"] == true
-        return Time.zone.parse(num["deadline_time"]).utc
+        return Time.zone.parse(num["deadline_time"]).in_time_zone("London")
       end
     end
   end

--- a/app/views/pages/_transfers.html.erb
+++ b/app/views/pages/_transfers.html.erb
@@ -1,31 +1,35 @@
 <div style="width: 100%" class="d-flex row justify-content-center">
-  <h2 style="margin-top: 25px; text-align: center"><strong>Gameweek <%= gameweek %> transfers</strong></h2>
-  <% @transfers.each do |key, value| %>
-    <% team = Fplteam.find_by(entry_name: key) %>
-    <% count = value[:out].count %>
-    <div class="transfer-team col-md-5" style="border-radius: 5px; background-color: #69b578; padding: 20px; margin: 10px;">
-      <div class="team-name" style="text-align: center">
-        <h3><strong><%= key %></strong></h3>
-        <h5><%= team.discord_name %></h5>
-        <p><%= team.free_hit?(team.entry, gameweek) ? "FREE HIT" : "" %></p>
-        <hr>
-      </div>
-      <div class="d-flex row justify-content-center">
-        <div class="transfers-out col-5">
-          <h5 style="text-align:center">Out</h5>
-          <% count.times do |i| %>
-            <% player = Player.find(value[:out][i - 1]) %>
-            <%= render 'player', player: player, position: player.element_type, selectedby: player.past_ownership_stats[gameweek.to_s], gameweek: gameweek  %>
-          <% end %>
+  <% if Pick.where(gameweek: gameweek).empty? %>
+    <h2 style="margin-top: 25px; text-align: center"><strong>Check back soon for Gameweek <%= gameweek %> transfers</strong></h2>
+  <% else %>
+    <h2 style="margin-top: 25px; text-align: center"><strong>Gameweek <%= gameweek %> transfers</strong></h2>
+    <% @transfers.each do |key, value| %>
+      <% team = Fplteam.find_by(entry_name: key) %>
+      <% count = value[:out].count %>
+      <div class="transfer-team col-md-5" style="border-radius: 5px; background-color: #69b578; padding: 20px; margin: 10px;">
+        <div class="team-name" style="text-align: center">
+          <h3><strong><%= key %></strong></h3>
+          <h5><%= team.discord_name %></h5>
+          <p><%= team.free_hit?(team.entry, gameweek) ? "FREE HIT" : "" %></p>
+          <hr>
         </div>
-        <div class="transfers-in col-5">
-          <h5 style="text-align:center">In</h5>
-          <% count.times do |i| %>
-            <% player = Player.find(value[:in][i - 1]) %>
-            <%= render 'player', player: player, position: player.element_type, selectedby: player.past_ownership_stats[gameweek.to_s], gameweek: gameweek  %>
-          <% end %>
+        <div class="d-flex row justify-content-center">
+          <div class="transfers-out col-5">
+            <h5 style="text-align:center">Out</h5>
+            <% count.times do |i| %>
+              <% player = Player.find(value[:out][i - 1]) %>
+              <%= render 'player', player: player, position: player.element_type, selectedby: player.past_ownership_stats[gameweek.to_s], gameweek: gameweek  %>
+            <% end %>
+          </div>
+          <div class="transfers-in col-5">
+            <h5 style="text-align:center">In</h5>
+            <% count.times do |i| %>
+              <% player = Player.find(value[:in][i - 1]) %>
+              <%= render 'player', player: player, position: player.element_type, selectedby: player.past_ownership_stats[gameweek.to_s], gameweek: gameweek  %>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
I noticed a few things that were going wrong and fixed them:
- The 'deadlines' tab was crashing after the deadline. This is because current team picks are not pulled until 90 mins after deadline. I did not want to change this as the game does not always refresh on time, so I deactivated the transfers tab until the 90 mins have passed.
- I realised that once we get to Gameweek 38, the code could crash because it will try to check for the next gameweek's deadline. Fixed this so it will not check for the deadline if the current gameweek is #38
- Deadlines went all weird after daylight savings began. This is because the FPL JSON has deadlines as UTC, and now we are in BST. Kind of a weird way of doing it, but okay! So I tweaked the deadline checker to always convert the deadlines to London time, all year round.