### PR TITLE
Season end proofing

### DIFF
--- a/app/services/gameweek.rb
+++ b/app/services/gameweek.rb
@@ -15,6 +15,7 @@ class Gameweek
         return num["id"]
       end
     end
+    return 38
   end
 
   def get_deadline
@@ -23,6 +24,7 @@ class Gameweek
         return Time.zone.parse(num["deadline_time"]).in_time_zone("London")
       end
     end
+    return Time.zone.parse("2024-05-19T13:30:00Z").in_time_zone("London")
   end
 
   def illegal_players

--- a/spec/services/gameweek_spec.rb
+++ b/spec/services/gameweek_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe Gameweek, type: :service do
+  # your tests go here
+  let(:api_data) { JSON.parse(File.read("./test/fixtures/api_data.json")) }
+  let(:end_of_season_data) { JSON.parse(File.read("./test/fixtures/end_of_season_data.json")) }
+  let(:time_relative) { "next" }
+  let(:gameweek) { Gameweek.new(api_data, time_relative) }
+  let(:end_of_season_gameweek) { Gameweek.new(end_of_season_data, time_relative) }
+
+  describe '#gw_num' do
+    it 'returns the correct gameweek number' do
+      # Replace 'expected_gw_num' with the expected gameweek number
+      expected_gw_num = 36
+      expect(gameweek.gw_num).to eq(expected_gw_num)
+    end
+  end
+
+  describe '#deadline' do
+    it 'returns the correct deadline time' do
+      # Replace 'expected_deadline' with the expected deadline time
+      expected_deadline = Time.zone.parse("2024-05-03T17:30:00Z").in_time_zone("London")
+      expect(gameweek.deadline).to eq(expected_deadline)
+    end
+  end
+
+  describe 'returns 38 at the end of the season' do
+    it 'returns 38 as the gameweek number at the end of the season' do
+      expect(end_of_season_gameweek.gw_num).to eq(38)
+    end
+  end
+
+  describe 'returns GW38s deadline at the end of the season' do
+    it 'returns 38 deadline as the gameweek deadline at the end of the season' do
+      expected_deadline = Time.zone.parse("2024-05-19T13:30:00Z").in_time_zone("London")
+      expect(end_of_season_gameweek.deadline).to eq(expected_deadline)
+    end
+  end
+
+end

--- a/test/fixtures/end_of_season_data.json
+++ b/test/fixtures/end_of_season_data.json
@@ -1,0 +1,25 @@
+{"events": [
+  {
+    "id": 37,
+    "name": "Gameweek 37",
+    "deadline_time": "2024-05-11T10:00:00Z",
+    "release_time": null,
+    "average_entry_score": 41,
+    "finished": false,
+    "data_checked": false,
+    "highest_scoring_entry": 2386791,
+    "deadline_time_epoch": 1715421600,
+    "deadline_time_game_offset": 0,
+    "highest_score": 125,
+    "is_previous": true,
+    "is_current": false,
+    "is_next": false
+  },
+{
+  "id": 38,
+  "name": "Gameweek 38",
+  "deadline_time": "2024-05-19T13:30:00Z",
+  "is_previous": false,
+  "is_current": true,
+  "is_next": false
+}]}


### PR DESCRIPTION
As we approach the end of the season, I needed to proof my code for when there are no 'future' gameweeks. A lot of my jobs look to the next gameweek to pull the next deadline. So now, the code should not do this, and when  it looks to the next gameweek and there isn't one, it will return the previous gameweek's data.